### PR TITLE
Episode 12 - Subnet ID property ID was failing Linter test

### DIFF
--- a/infrastructure/core.bicep
+++ b/infrastructure/core.bicep
@@ -137,7 +137,7 @@ module cosmosPrivateLink 'br:bicepreg.azurecr.io/bicep/modules/privateendpoint:v
     location:location
     name: '${prefix}-cosmos'
     virtualNetworkId: virtualNetwork.id
-    subnetName: virtualNetwork.properties.subnets[0].name
+    subnetId: virtualNetwork.properties.subnets[0].id
     zoneName: 'privatelink.documents.azure.com'
     subResourceTypes:[
        'SQL'
@@ -168,7 +168,7 @@ module keyVaultPrivateLink 'br:bicepreg.azurecr.io/bicep/modules/privateendpoint
     location:location
     name: '${prefix}-keyvault'
     virtualNetworkId: virtualNetwork.id
-    subnetName: virtualNetwork.properties.subnets[0].name
+    subnetId: virtualNetwork.properties.subnets[0].id
     zoneName: 'privatelink.vaultcore.azure.net'
     subResourceTypes:[
        'vault'

--- a/modules/private-endpoint.bicep
+++ b/modules/private-endpoint.bicep
@@ -1,7 +1,7 @@
 param name string
 param location string
 param virtualNetworkId string
-param subnetName string
+param subnetId string
 param resourceId string
 param subResourceTypes array
 param zoneName string
@@ -38,7 +38,7 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2021-08-01'  = {
     ]
     subnet: {
       
-      id: '${virtualNetworkId}/subnets/${subnetName}'
+      id: subnetId
     }
   
   }


### PR DESCRIPTION
Hi Sam,

From episode 12, the Subnet ID property ID in private-endpoint.bicep was failing the Linter test on rule - **use resource ID functions** so I passed through the Subnet ID as a parameter form the core.bicep file instead of the Subnet Name which passes the tests and deploys ok.

Just thought this might help in case anyone else has this issue.

Great course!

Alan